### PR TITLE
 change package import to context (Go1.9)

### DIFF
--- a/gae/bq/bigquery.go
+++ b/gae/bq/bigquery.go
@@ -2,11 +2,11 @@ package bq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strconv"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/taskqueue"
 

--- a/gae/ds/datastore.go
+++ b/gae/ds/datastore.go
@@ -1,6 +1,7 @@
 package ds
 
 import (
+	"context"
 	"crypto/md5"
 	goerrors "errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/knightso/base/errors"
 	"github.com/qedus/nds"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )

--- a/gae/ds/map_test.go
+++ b/gae/ds/map_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func Test(t *testing.T) {
-	c, err := aetest.NewContext(nil)
+	c, done, err := aetest.NewContext()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer done()
 
 	m := NewSyncMap()
 

--- a/gae/gae.go
+++ b/gae/gae.go
@@ -1,6 +1,7 @@
 package gae
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/knightso/base/gae/bq"
 	"github.com/martini-contrib/render"
 	"github.com/pborman/uuid"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	aelog "google.golang.org/appengine/log"
 )


### PR DESCRIPTION
- change package import from golang.org/x/net/context to context
- fix usage of astest.NewContext
- ignore `golint` or `go vet` error