### PR TITLE
エラーハンドリング簡素化のため、Wrap系関数にnilをスルーする挙動を追加

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -82,14 +82,23 @@ func (e *BaseError) ErrorWithStackTrace() string {
 }
 
 func Wrap(e error, msg string) *BaseError {
+	if e == nil {
+		return nil
+	}
 	return _new(e, msg, 3)
 }
 
 func Wrapf(e error, msg string, args ...interface{}) *BaseError {
+	if e == nil {
+		return nil
+	}
 	return _new(e, fmt.Sprintf(msg, args...), 3)
 }
 
 func WrapOr(e error) *BaseError {
+	if e == nil {
+		return nil
+	}
 	if ee, ok := e.(*BaseError); ok {
 		return ee
 	}


### PR DESCRIPTION
# 目的

以下のように、ラッパー的な挙動をする関数のエラーハンドリングを少し簡素化することが目的です

## before

```
func internal(n int) error {
    if n%2 == 0 {
        return fmt.Errorf("偶数: %d", n)
    }

    return nil
}

func External(n int) error {
    if err := internal(n); err != nil {
        return errors.Wrap(err)
    }

    return nil
}
```

## after

```
func internal(n int) error {
    if n%2 == 0 {
        return fmt.Errorf("偶数: %d", n)
    }

    return nil
}

func External(n int) error {
   return errors.Wrap(internal(n))
}
```