### PR TITLE
エラーラップ系関数の返り値の型を *BaseError → error に変更

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -81,21 +81,21 @@ func (e *BaseError) ErrorWithStackTrace() string {
 	return buf.String()
 }
 
-func Wrap(e error, msg string) *BaseError {
+func Wrap(e error, msg string) error {
 	if e == nil {
 		return nil
 	}
 	return _new(e, msg, 3)
 }
 
-func Wrapf(e error, msg string, args ...interface{}) *BaseError {
+func Wrapf(e error, msg string, args ...interface{}) error {
 	if e == nil {
 		return nil
 	}
 	return _new(e, fmt.Sprintf(msg, args...), 3)
 }
 
-func WrapOr(e error) *BaseError {
+func WrapOr(e error) error {
 	if e == nil {
 		return nil
 	}


### PR DESCRIPTION
#7 の対応漏れ
#7 の状態だと、各関数に `(error)(nil)` が渡った際の返り値が `(*BaseError)(nil)` になってしまい、正しくエラーハンドリングできなくなってしまっていた